### PR TITLE
utilize async-friendly library

### DIFF
--- a/pAPI/info.json
+++ b/pAPI/info.json
@@ -1,10 +1,14 @@
 {
-    "author" : 9003,
-    "install_msg" : "A message you wish to display to users after they sucessfully install your cog.",
-    "name" : "pAPI",
-    "short" : "A short description. Displayed in the `[p]cog list` command.",
-    "requirements" : [],
-    "description" : "Full description of your cog. Displayed on the Red Portal and with `[p]cog info`",
-    "permissions" : [],
-    "tags" : []
+    "author": [
+        "9003"
+    ],
+    "install_msg": "A message you wish to display to users after they sucessfully install your cog.",
+    "name": "pAPI",
+    "short": "A short description. Displayed in the `[p]cog list` command.",
+    "requirements": [
+        "sans"
+    ],
+    "description": "Full description of your cog. Displayed on the Red Portal and with `[p]cog info`",
+    "permissions": [],
+    "tags": []
 }

--- a/pAPI/pAPI.py
+++ b/pAPI/pAPI.py
@@ -1,95 +1,87 @@
 from redbot.core import commands
-import requests
-import time
+import asyncio
+import sans
+
 
 class pAPI(commands.Cog):
     """My custom cog"""
 
     def __init__(self, bot):
         self.bot = bot
-        self.password=""
-        self.RegionalNation=""
-        
+        self.auth = sans.NSAuth()
+        self.RegionalNation = ""
+        self.client = sans.AsyncClient()
 
-    def api_request(self,data, header,_limit=0):
-        if _limit > 50:
-            return
-        url = "https://www.nationstates.net/cgi-bin/api.cgi"
-        response = requests.post(url, data=data, headers=header)
-        head = response.headers
-        if waiting_time := head.get("Retry-After"):
-            time.sleep(int(waiting_time)+1)
-            self.api_request(data,header,_limit+1)
-        try:
-            requests_left = int(head["X-RateLimit-Remaining"])
-        except KeyError:
-            requests_left = int(head["RateLimit-Remaining"])
-        try:
-            seconds_until_reset = int(head["X-RateLimit-Reset"])
-        except KeyError:
-            seconds_until_reset = int(head["RateLimit-Reset"])
-        time.sleep(seconds_until_reset / requests_left)
+    def cog_unload(self):
+        asyncio.create_task(self.client.aclose())
+
+    async def cog_command_error(self, ctx, error):
+        await ctx.send(" ".join(error.args))
+
+    async def api_request(self, data) -> sans.Response:
+        response = await self.client.post(sans.World(**data), auth=self.auth)
+        response.raise_for_status()
         return response
 
-            
-    @commands.command(pass_context=True)
-    async def pAPI_version(self,ctx):
-        await ctx.send("This is version 1.4")
-    
-        
-    
-    @commands.command(pass_context=True)
-    async def rmb_post(self, ctx, User_Agent, Region, *msg):
-        output = ""
-        for each in msg:
-            output=output+each+" "
-        data={"nation":self.RegionalNation,"region":Region,"c":"rmbpost","text":output,"mode":"prepare"}
-        r = self.api_request(data=data,header={"User-Agent":User_Agent,'X-Password':self.password})
-        rmbToken = r.text.replace(f'<NATION id="{self.RegionalNation}">\n<SUCCESS>',"")
-        rmbToken = rmbToken.replace('</SUCCESS>\n</NATION>',"")
-        rmbToken = rmbToken.strip()
-        data = {"nation":self.RegionalNation,"region":Region,"c":"rmbpost","text":output,"mode":"execute","token":rmbToken}
-        headerz = {'User-Agent': User_Agent, 'X-pin': r.headers["x-pin"]}
-        r = self.api_request(data=data,header=headerz)
-        if str(r.status_code) == "200":
-            await ctx.send(f"Posted on  {Region} RMB")
-        else:
-            await ctx.send(r.text)
-        
-        
-    @commands.command(pass_context=True)
-    async def gift_card(self, ctx, User_Agent, giftie, cardid, season):
-        await ctx.send(f"Attempting to gift {cardid} to {giftie} from {self.RegionalNation}")
-        headers = {"User-Agent": User_Agent, 'X-Password':self.password}
-        data = {'nation': self.RegionalNation, 'cardid': cardid, 'season': season, 'to': giftie, 'mode': "prepare", 'c': 'giftcard'}
-        r = self.api_request(data, headers)
-        giftToken = r.text.replace(f'<NATION id="{self.RegionalNation}">\n<SUCCESS>',"")
-        giftToken = giftToken.replace('</SUCCESS>\n</NATION>',"")
-        giftToken= giftToken.strip()
-        #await ctx.send(r.headers)
-        headerz = {'User-Agent': User_Agent, 'X-pin': r.headers["x-pin"]}
-        data = {'nation': self.RegionalNation, 'cardid': cardid, 'season': season, 'token': giftToken, 'to': giftie, 'mode': "execute", 'c': 'giftcard'}
-        z2 = self.api_request(data=data, header=headerz)
-        #await ctx.send(z2.content)
-        if str(z2.status_code) == "200":
-            await ctx.send(f"Gifted {cardid}, season {season} to {giftie}")
-        else:
-            await ctx.send(z2.text)
+    @commands.command()
+    async def pAPI_agent(self, ctx, *, agent):
+        sans.set_agent(agent, _force=True)
+        await ctx.send("Agent set.")
 
-    @commands.command(pass_context=True)
-    async def set_regional_nation(self,ctx,*nation):
-        nation=str(nation).replace("(","").replace(")","").replace(",","").replace("'","").replace(" ","_")
-        nation = nation.lower()
-        self.RegionalNation=nation
+    @commands.command()
+    async def pAPI_version(self, ctx):
+        await ctx.send("This is version 1.4")
+
+    @commands.command()
+    async def rmb_post(self, ctx, Region, *, msg):
+        output = msg
+        data = {
+            "nation": self.RegionalNation,
+            "region": Region,
+            "c": "rmbpost",
+            "text": output,
+            "mode": "prepare",
+        }
+        r = await self.api_request(data=data)
+        rmbToken = r.xml.find("SUCCESS").text
+        data.update(mode="execute", token=rmbToken)
+        r = await self.api_request(data=data)
+        await ctx.send(f"Posted on  {Region} RMB")
+
+    @commands.command()
+    async def gift_card(self, ctx, giftie, cardid, season):
+        await ctx.send(
+            f"Attempting to gift {cardid} to {giftie} from {self.RegionalNation}"
+        )
+        data = {
+            "nation": self.RegionalNation,
+            "cardid": cardid,
+            "season": season,
+            "to": giftie,
+            "mode": "prepare",
+            "c": "giftcard",
+        }
+        r = await self.api_request(data)
+        giftToken = r.xml.find("SUCCESS").text
+        # await ctx.send(r.headers)
+        data.update(mode="execute", token=giftToken)
+        await self.api_request(data=data)
+        # await ctx.send(z2.content)
+        await ctx.send(f"Gifted {cardid}, season {season} to {giftie}")
+
+    @commands.command()
+    async def set_regional_nation(self, ctx, *, nation):
+        nation = "_".join(nation.lower().split())
+        self.RegionalNation = nation
         await ctx.send(f"Set regional nation to {self.RegionalNation}")
 
-    @commands.command(pass_context=True)
-    async def set_regional_nation_password(self,ctx,password2):
-        self.password = password2
+    @commands.command()
+    async def set_regional_nation_password(self, ctx, *, password2):
+        self.auth = sans.NSAuth(password=password2)
         await ctx.send(f"Set regional nation password for {self.RegionalNation}.")
 
-    @commands.command(pass_context=True)
-    async def clear_regional_nation(self,ctx):
+    @commands.command()
+    async def clear_regional_nation(self, ctx):
         await ctx.send("Voiding any saved data on the regional Nation")
-        self.password=""
-        self.RegionalNation=""
+        self.auth = sans.NSAuth()
+        self.RegionalNation = ""


### PR DESCRIPTION
- utilized sans
- agent is set via a separate command now to work better with sans
- also adds some miscellaneous d.py-related changes:
  - `pass_context=True` no longer does anything
  - utilized consume-rest via `*, arg` over `*arg`, which allows for spaces in the argument without having to re-merge them yourself

if desired I can add comments to the code explaining what each thing does